### PR TITLE
Add public-read ACL to S3 upload command

### DIFF
--- a/.github/workflows/deploy-react-to-s3.yaml
+++ b/.github/workflows/deploy-react-to-s3.yaml
@@ -31,5 +31,5 @@ jobs:
           aws-region: us-east-1
     
       - name: Upload to S3
-        run: aws s3 sync out/ s3://shop-comp-s3-bucket --delete
+        run: aws s3 sync out/ s3://shop-comp-s3-bucket --delete --acl public-read
 


### PR DESCRIPTION
This should make the objects publicly accessible and prevent the "403 Forbidden" error