### PR TITLE
Applied fix for S3 page navigation

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,7 +3,10 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   /* config options here */
   output: "export",
-  basePath: "/shopcomp",
+  trailingSlash: true,
+  images: {
+    unoptimized: true,
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
The `trailingSlash` was important to generate `/login/index.html`, `/dashboard/index.html`, etc. files