### PR TITLE
Edit Receipts Page to use ListReceipts

### DIFF
--- a/src/app/receipts/boundary.tsx
+++ b/src/app/receipts/boundary.tsx
@@ -18,7 +18,7 @@ export function ReceiptSearch() {
     }
 
     const receiptToString = (receipt: Receipt): string => {
-        return receipt.storeName + " - " + receipt.date.slice(0, receipt.date.length - 3) + " - $" + receipt.totalAmount;
+        return receipt.storeName + " - " + receipt.date.slice(0, receipt.date.length - 3) + " - $" + receipt.totalAmount.toFixed(2);
     }
 
     // the persistent list of receipts from the API call


### PR DESCRIPTION
Get rid of the mock adapter and instead use ListReceipts for the receipts search bar.
Closes #55 